### PR TITLE
fix: add new cube iff old cubes move

### DIFF
--- a/src/cube.js
+++ b/src/cube.js
@@ -22,4 +22,8 @@ export default class Cube {
     this.z = z;
     return this;
   };
+
+  get position() {
+    return { x: this.x, y: this.y, z: this.z }
+  }
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -140,7 +140,10 @@ export default class Manager {
         this.moveCube(cube, positions.furthest);
       }
 
-      moved = !isEqual(position, cube);
+      // `moved` indicates if at least one cube has changed position
+      // isEqual compares (by value) new position with old position.
+      // iff at least one cube has moved, we can add another cube.
+      moved ||= !isEqual(position, cube.position);
     });
 
     if (moved) {


### PR DESCRIPTION
fix bug in moveCubes where new cubes are added even if positions of old cubes do not change. The game we are cloning has the constraint where a new cube is only added if the positions of previous cubes changes.

Two quick fixes:
- first, isEqual needs two objects with the same shape, so there's a new Cube getter to return just x,y,z
- second, each cubes movement needs to be or'd into `moved`-- if any cubes moved, then we need to add a new cube. Using a fancy  [logical or assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment) because it feels perfect for this application (and besides, how often have you seen `||=` in non-compiled js?).
  - if you wanted to get *really* fancy I think you could use DeMorgan's law and flip repeated || !isEqual with repeated && isEqual and flip the output (ie `!moved || !moved || ... === !(moved && moved && ...)`)

PS: I went to, and thoroughly enjoyed, your talk at qcon sf last week.